### PR TITLE
add GMP and MCrypt to builds

### DIFF
--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -20,6 +20,8 @@ RUN set -ex; \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
@@ -34,17 +36,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -21,6 +21,8 @@ RUN set -ex; \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
@@ -34,17 +36,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 	runDeps="$( \

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex; \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
-		libgmp-dev \
+		gmp-dev \
 		libmcrypt-dev \
 	; \
 	\

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -17,6 +17,8 @@ RUN set -ex; \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
@@ -31,17 +33,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -21,6 +21,8 @@ RUN set -ex; \
 		libpng-dev \
 		libpq-dev \
 		libzip-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
@@ -35,17 +37,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -22,6 +22,8 @@ RUN set -ex; \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
@@ -35,17 +37,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 	runDeps="$( \

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex; \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
-		libgmp-dev \
+		gmp-dev \
 		libmcrypt-dev \
 	; \
 	\

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -18,6 +18,8 @@ RUN set -ex; \
 		libpng-dev \
 		libpq-dev \
 		libzip-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
@@ -32,17 +34,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -21,6 +21,8 @@ RUN set -ex; \
 		libpng-dev \
 		libpq-dev \
 		libzip-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg; \
@@ -35,17 +37,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex; \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
-		libgmp-dev \
+		gmp-dev \
 		libmcrypt-dev \
 	; \
 	\

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -22,6 +22,8 @@ RUN set -ex; \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg; \
@@ -35,17 +37,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 	runDeps="$( \

--- a/php7.4/fpm/Dockerfile
+++ b/php7.4/fpm/Dockerfile
@@ -18,6 +18,8 @@ RUN set -ex; \
 		libpng-dev \
 		libpq-dev \
 		libzip-dev \
+		libgmp-dev \
+		libmcrypt-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-jpeg; \
@@ -32,17 +34,20 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+		gmp \
 	; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.18; \
 	pecl install memcached-3.1.5; \
 	pecl install redis-4.3.0; \
+	pecl install mcrypt-1.0.3; \
 	\
 	docker-php-ext-enable \
 		apcu \
 		memcached \
 		redis \
+		mcrypt \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/update.sh
+++ b/update.sh
@@ -32,6 +32,7 @@ declare -A pecl_versions=(
 	[php7-APCu]='5.1.18'
 	[php7-memcached]='3.1.5'
 	[php7-redis]='4.3.0'
+	[php7-mcrypt]='1.0.3'
 )
 
 travisEnv=
@@ -62,6 +63,7 @@ for phpVersion in "${phpVersions[@]}"; do
 				-e 's!%%APCU_VERSION%%!'"${pecl_versions[$phpMajorVersion-APCu]}"'!g' \
 				-e 's!%%MEMCACHED_VERSION%%!'"${pecl_versions[$phpMajorVersion-memcached]}"'!g' \
 				-e 's!%%REDIS_VERSION%%!'"${pecl_versions[$phpMajorVersion-redis]}"'!g' \
+				-e 's!%%MCRYPT_VERSION%%!'"${pecl_versions[$phpMajorVersion-mcrypt]}"'!g' \
 				-e 's!%%CMD%%!'"$cmd"'!g' \
 				"Dockerfile-${base}.template" > "$dir/Dockerfile"
 


### PR DESCRIPTION
add GMP and MCrypt to builds

GMP Is needed for Webauthn testing - more info  https://github.com/joomla/joomla-cms/issues/29696 https://github.com/joomla/joomla-cms/pull/29731

MCrypt is needed for testing deprecated JCrypt - more info https://github.com/joomla/joomla-cms/issues/29830