### PR TITLE
Added optional environment variable JOOMLA_DB_PASSWORD_FILE

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+        JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
+fi
+
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then


### PR DESCRIPTION
This environment variable is crucial for Docker secrets, as Docker secrets can only be files mounted to a specific path. Without support for reading the password out of a file, we are forced to define the database password in the docker-compose file which is not very secure.