### PR TITLE
Give a chance for using an alternative method to attach database.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         
-        if [ -z "$IGNORE_DB_CREATING"]; then
+        if [ -z "$IGNORE_DB_CREATING" ]; then
 
                 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                         if [ -z "$JOOMLA_DB_HOST" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,41 +10,41 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         
         if [ -z "$IGNORE_DB_CREATING"]; then
 
-        if [ -n "$MYSQL_PORT_3306_TCP" ]; then
-                if [ -z "$JOOMLA_DB_HOST" ]; then
-                        JOOMLA_DB_HOST='mysql'
-                else
-                        echo >&2 "warning: both JOOMLA_DB_HOST and MYSQL_PORT_3306_TCP found"
-                        echo >&2 "  Connecting to JOOMLA_DB_HOST ($JOOMLA_DB_HOST)"
-                        echo >&2 "  instead of the linked mysql container"
+                if [ -n "$MYSQL_PORT_3306_TCP" ]; then
+                        if [ -z "$JOOMLA_DB_HOST" ]; then
+                                JOOMLA_DB_HOST='mysql'
+                        else
+                                echo >&2 "warning: both JOOMLA_DB_HOST and MYSQL_PORT_3306_TCP found"
+                                echo >&2 "  Connecting to JOOMLA_DB_HOST ($JOOMLA_DB_HOST)"
+                                echo >&2 "  instead of the linked mysql container"
+                        fi
                 fi
-        fi
 
-        if [ -z "$JOOMLA_DB_HOST" ]; then
-                echo >&2 "error: missing JOOMLA_DB_HOST and MYSQL_PORT_3306_TCP environment variables"
-                echo >&2 "  Did you forget to --link some_mysql_container:mysql or set an external db"
-                echo >&2 "  with -e JOOMLA_DB_HOST=hostname:port?"
-                exit 1
-        fi
+                if [ -z "$JOOMLA_DB_HOST" ]; then
+                        echo >&2 "error: missing JOOMLA_DB_HOST and MYSQL_PORT_3306_TCP environment variables"
+                        echo >&2 "  Did you forget to --link some_mysql_container:mysql or set an external db"
+                        echo >&2 "  with -e JOOMLA_DB_HOST=hostname:port?"
+                        exit 1
+                fi
 
-        # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ]; then
-                : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
-        fi
-        : ${JOOMLA_DB_NAME:=joomla}
+                # If the DB user is 'root' then use the MySQL root password env var
+                : ${JOOMLA_DB_USER:=root}
+                if [ "$JOOMLA_DB_USER" = 'root' ]; then
+                        : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
+                fi
+                : ${JOOMLA_DB_NAME:=joomla}
 
-        if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
-                echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
-                echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
-                echo >&2
-                echo >&2 "  (Also of interest might be JOOMLA_DB_USER and JOOMLA_DB_NAME.)"
-                exit 1
-        fi
-        # Ensure the MySQL Database is created
-        php /makedb.php "$JOOMLA_DB_HOST" "$JOOMLA_DB_USER" "$JOOMLA_DB_PASSWORD" "$JOOMLA_DB_NAME"
+                if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
+                        echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
+                        echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
+                        echo >&2
+                        echo >&2 "  (Also of interest might be JOOMLA_DB_USER and JOOMLA_DB_NAME.)"
+                        exit 1
+                fi
+                # Ensure the MySQL Database is created
+                php /makedb.php "$JOOMLA_DB_HOST" "$JOOMLA_DB_USER" "$JOOMLA_DB_PASSWORD" "$JOOMLA_DB_NAME"
 
-        fi # if [[ -z "$IGNORE_DB_CREATING"]]; then
+        fi
 
 
         if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,9 @@ if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        
+        if [ -z "$IGNORE_DB_CREATING"]; then
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -38,6 +41,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 echo >&2 "  (Also of interest might be JOOMLA_DB_USER and JOOMLA_DB_NAME.)"
                 exit 1
         fi
+        # Ensure the MySQL Database is created
+        php /makedb.php "$JOOMLA_DB_HOST" "$JOOMLA_DB_USER" "$JOOMLA_DB_PASSWORD" "$JOOMLA_DB_NAME"
+
+        fi # if [[ -z "$IGNORE_DB_CREATING"]]; then
+
 
         if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
                 echo >&2 "Joomla not found in $(pwd) - copying now..."
@@ -58,8 +66,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
         fi
 
-        # Ensure the MySQL Database is created
-        php /makedb.php "$JOOMLA_DB_HOST" "$JOOMLA_DB_USER" "$JOOMLA_DB_PASSWORD" "$JOOMLA_DB_NAME"
 
         echo >&2 "========================================================================"
         echo >&2


### PR DESCRIPTION
Joomla accepts MySQL or Postgres for a database.

Example:
$ docker run -d -rm --name dbservice -e MYSQL_ROOT_PASSWORD=JOOMLA_DB_PASSWORD -e MYSQL_DATABASE=JOOMLA_DB_NAME -e MYSQL_USER=JOOMLA_DB_USER mysql
or
$ docker run -d -rm --name dbservice -e POSTGRES_PASSWORD=JOOMLA_DB_PASSWORD -e POSTGRES_DB=JOOMLA_DB_NAME -e POSTGRES_USER=JOOMLA_DB_USER postgres

then
$ docker run -d -rm --name some-joomla -e IGNORE_DB_CREATING='' -p 8080:80 --link dbservice:JOOMLA_DB_HOST joomla

By defining -e IGNORE_DB_CREATING it's possible to skip mysql db creation.

I myself quiet don't understand why joomla image messes with creating database and believe that the embraced in if [ -z "$IGNORE_DB_CREATING"]; part should be deleted.