### PR TITLE
Added php intl extension to all version 4 dockerfiles (not tested!)

### DIFF
--- a/4.0/php7.4/apache/Dockerfile
+++ b/4.0/php7.4/apache/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libicu-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
@@ -37,6 +38,7 @@ RUN set -ex; \
 		bz2 \
 		gd \
 		gmp \
+		intl \
 		ldap \
 		mysqli \
 		pdo_mysql \

--- a/4.0/php7.4/fpm-alpine/Dockerfile
+++ b/4.0/php7.4/fpm-alpine/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex; \
 		autoconf \
 		bzip2-dev \
 		gmp-dev \
+		icu-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
@@ -37,6 +38,7 @@ RUN set -ex; \
 		bz2 \
 		gd \
 		gmp \
+		intl \
 		ldap \
 		mysqli \
 		pdo_mysql \

--- a/4.0/php7.4/fpm/Dockerfile
+++ b/4.0/php7.4/fpm/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libicu-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
@@ -35,6 +36,7 @@ RUN set -ex; \
 		bz2 \
 		gd \
 		gmp \
+		intl \
 		ldap \
 		mysqli \
 		pdo_mysql \

--- a/4.0/php8.0/apache/Dockerfile
+++ b/4.0/php8.0/apache/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libicu-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
@@ -37,6 +38,7 @@ RUN set -ex; \
 		bz2 \
 		gd \
 		gmp \
+		intl \
 		ldap \
 		mysqli \
 		pdo_mysql \

--- a/4.0/php8.0/fpm-alpine/Dockerfile
+++ b/4.0/php8.0/fpm-alpine/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex; \
 		autoconf \
 		bzip2-dev \
 		gmp-dev \
+		icu-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
@@ -37,6 +38,7 @@ RUN set -ex; \
 		bz2 \
 		gd \
 		gmp \
+		icu \
 		ldap \
 		mysqli \
 		pdo_mysql \

--- a/4.0/php8.0/fpm/Dockerfile
+++ b/4.0/php8.0/fpm/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libicu-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
@@ -35,6 +36,7 @@ RUN set -ex; \
 		bz2 \
 		gd \
 		gmp \
+		intl \
 		ldap \
 		mysqli \
 		pdo_mysql \


### PR DESCRIPTION
This extension is now recommended by the Joomla! update component when upgrading to version 4.0.3, so I seized the opportunity and updated the official dockerfiles for version 4 to include it by default. However, these changes are not yet verified to work properly, so some minor adjustments may be required.