### PR TITLE
Major Image Improvments and Version Increment

### DIFF
--- a/3.10/php7.3/apache/Dockerfile
+++ b/3.10/php7.3/apache/Dockerfile
@@ -74,8 +74,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 3.10.4
-ENV JOOMLA_SHA512 c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510
+ENV JOOMLA_VERSION 3.10.5
+ENV JOOMLA_SHA512 c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/3.10/php7.3/apache/Dockerfile
+++ b/3.10/php7.3/apache/Dockerfile
@@ -10,9 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Enable Apache Rewrite Module
-RUN a2enmod rewrite
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -21,20 +27,30 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
+	docker-php-ext-configure gd \
+		--with-freetype-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-png-dir=/usr \
+		--with-webp-dir=/usr \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		ldap \
@@ -44,7 +60,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -60,7 +88,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -69,7 +97,55 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 
@@ -86,7 +162,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/3.10/php7.3/apache/docker-entrypoint.sh
+++ b/3.10/php7.3/apache/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/3.10/php7.3/fpm-alpine/Dockerfile
+++ b/3.10/php7.3/fpm-alpine/Dockerfile
@@ -10,10 +10,17 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# entrypoint.sh dependencies
-RUN apk add --no-cache \
-	bash
-# Install the PHP extensions
+RUN set -eux; \
+	apk add --no-cache \
+# in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
+		bash \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files
+		imagemagick \
+	;
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
@@ -21,20 +28,31 @@ RUN set -ex; \
 		autoconf \
 		bzip2-dev \
 		gmp-dev \
+		freetype-dev \
+		imagemagick-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
-	docker-php-ext-configure ldap; \
+	docker-php-ext-configure gd \
+		--with-freetype-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-png-dir=/usr \
+		--with-webp-dir=/usr \
+	; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		ldap \
@@ -44,6 +62,20 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
+	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
@@ -60,13 +92,43 @@ RUN set -ex; \
 	rm -r /tmp/pear; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		)"; \
-	apk add --virtual .joomla-phpext-rundeps $runDeps; \
-	apk del .build-deps
+		scanelf --needed --nobanner --format '%n#p' --recursive "$extDir" \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .joomla-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -83,7 +145,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/3.10/php7.3/fpm-alpine/Dockerfile
+++ b/3.10/php7.3/fpm-alpine/Dockerfile
@@ -71,8 +71,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 3.10.4
-ENV JOOMLA_SHA512 c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510
+ENV JOOMLA_VERSION 3.10.5
+ENV JOOMLA_SHA512 c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/3.10/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/3.10/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/3.10/php7.3/fpm/Dockerfile
+++ b/3.10/php7.3/fpm/Dockerfile
@@ -10,7 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -19,20 +27,30 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
+	docker-php-ext-configure gd \
+		--with-freetype-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-png-dir=/usr \
+		--with-webp-dir=/usr \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		ldap \
@@ -42,7 +60,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -58,7 +88,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -67,7 +97,37 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -84,7 +144,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/3.10/php7.3/fpm/Dockerfile
+++ b/3.10/php7.3/fpm/Dockerfile
@@ -72,8 +72,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 3.10.4
-ENV JOOMLA_SHA512 c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510
+ENV JOOMLA_VERSION 3.10.5
+ENV JOOMLA_SHA512 c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/3.10/php7.3/fpm/docker-entrypoint.sh
+++ b/3.10/php7.3/fpm/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/3.10/php7.4/apache/Dockerfile
+++ b/3.10/php7.4/apache/Dockerfile
@@ -10,9 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Enable Apache Rewrite Module
-RUN a2enmod rewrite
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -21,20 +27,29 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		ldap \
@@ -44,7 +59,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -60,7 +87,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -69,7 +96,55 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 
@@ -86,7 +161,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/3.10/php7.4/apache/Dockerfile
+++ b/3.10/php7.4/apache/Dockerfile
@@ -74,8 +74,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 3.10.4
-ENV JOOMLA_SHA512 c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510
+ENV JOOMLA_VERSION 3.10.5
+ENV JOOMLA_SHA512 c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/3.10/php7.4/apache/docker-entrypoint.sh
+++ b/3.10/php7.4/apache/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/3.10/php7.4/fpm-alpine/Dockerfile
+++ b/3.10/php7.4/fpm-alpine/Dockerfile
@@ -10,10 +10,17 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# entrypoint.sh dependencies
-RUN apk add --no-cache \
-	bash
-# Install the PHP extensions
+RUN set -eux; \
+	apk add --no-cache \
+# in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
+		bash \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files
+		imagemagick \
+	;
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
@@ -21,20 +28,30 @@ RUN set -ex; \
 		autoconf \
 		bzip2-dev \
 		gmp-dev \
+		freetype-dev \
+		imagemagick-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
-	docker-php-ext-configure ldap; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		ldap \
@@ -44,6 +61,20 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
+	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
@@ -60,13 +91,43 @@ RUN set -ex; \
 	rm -r /tmp/pear; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		)"; \
-	apk add --virtual .joomla-phpext-rundeps $runDeps; \
-	apk del .build-deps
+		scanelf --needed --nobanner --format '%n#p' --recursive "$extDir" \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .joomla-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -83,7 +144,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/3.10/php7.4/fpm-alpine/Dockerfile
+++ b/3.10/php7.4/fpm-alpine/Dockerfile
@@ -71,8 +71,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 3.10.4
-ENV JOOMLA_SHA512 c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510
+ENV JOOMLA_VERSION 3.10.5
+ENV JOOMLA_SHA512 c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/3.10/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/3.10/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/3.10/php7.4/fpm/Dockerfile
+++ b/3.10/php7.4/fpm/Dockerfile
@@ -72,8 +72,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 3.10.4
-ENV JOOMLA_SHA512 c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510
+ENV JOOMLA_VERSION 3.10.5
+ENV JOOMLA_SHA512 c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/3.10/php7.4/fpm/Dockerfile
+++ b/3.10/php7.4/fpm/Dockerfile
@@ -10,7 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -19,20 +27,29 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		ldap \
@@ -42,7 +59,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -58,7 +87,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -67,7 +96,37 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -84,7 +143,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/3.10/php7.4/fpm/docker-entrypoint.sh
+++ b/3.10/php7.4/fpm/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/4.0/php7.4/apache/Dockerfile
+++ b/4.0/php7.4/apache/Dockerfile
@@ -10,9 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Enable Apache Rewrite Module
-RUN a2enmod rewrite
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -22,20 +28,29 @@ RUN set -ex; \
 		libbz2-dev \
 		libgmp-dev \
 		libicu-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		intl \
@@ -46,7 +61,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -62,7 +89,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -71,7 +98,55 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 
@@ -88,7 +163,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/4.0/php7.4/apache/Dockerfile
+++ b/4.0/php7.4/apache/Dockerfile
@@ -76,8 +76,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.0.5
-ENV JOOMLA_SHA512 8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877
+ENV JOOMLA_VERSION 4.0.6
+ENV JOOMLA_SHA512 a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/4.0/php7.4/apache/docker-entrypoint.sh
+++ b/4.0/php7.4/apache/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/4.0/php7.4/fpm-alpine/Dockerfile
+++ b/4.0/php7.4/fpm-alpine/Dockerfile
@@ -73,8 +73,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.0.5
-ENV JOOMLA_SHA512 8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877
+ENV JOOMLA_VERSION 4.0.6
+ENV JOOMLA_SHA512 a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/4.0/php7.4/fpm-alpine/Dockerfile
+++ b/4.0/php7.4/fpm-alpine/Dockerfile
@@ -10,10 +10,17 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# entrypoint.sh dependencies
-RUN apk add --no-cache \
-	bash
-# Install the PHP extensions
+RUN set -eux; \
+	apk add --no-cache \
+# in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
+		bash \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files
+		imagemagick \
+	;
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
@@ -22,20 +29,30 @@ RUN set -ex; \
 		bzip2-dev \
 		gmp-dev \
 		icu-dev \
+		freetype-dev \
+		imagemagick-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
-	docker-php-ext-configure ldap; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		intl \
@@ -46,6 +63,20 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
+	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
@@ -62,13 +93,43 @@ RUN set -ex; \
 	rm -r /tmp/pear; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		)"; \
-	apk add --virtual .joomla-phpext-rundeps $runDeps; \
-	apk del .build-deps
+		scanelf --needed --nobanner --format '%n#p' --recursive "$extDir" \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .joomla-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -85,7 +146,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/4.0/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/4.0/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/4.0/php7.4/fpm/Dockerfile
+++ b/4.0/php7.4/fpm/Dockerfile
@@ -74,8 +74,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.0.5
-ENV JOOMLA_SHA512 8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877
+ENV JOOMLA_VERSION 4.0.6
+ENV JOOMLA_SHA512 a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/4.0/php7.4/fpm/Dockerfile
+++ b/4.0/php7.4/fpm/Dockerfile
@@ -10,7 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -20,20 +28,29 @@ RUN set -ex; \
 		libbz2-dev \
 		libgmp-dev \
 		libicu-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		intl \
@@ -44,7 +61,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -60,7 +89,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -69,7 +98,37 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -86,7 +145,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/4.0/php7.4/fpm/docker-entrypoint.sh
+++ b/4.0/php7.4/fpm/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/4.0/php8.0/apache/Dockerfile
+++ b/4.0/php8.0/apache/Dockerfile
@@ -10,9 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Enable Apache Rewrite Module
-RUN a2enmod rewrite
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -22,20 +28,29 @@ RUN set -ex; \
 		libbz2-dev \
 		libgmp-dev \
 		libicu-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		intl \
@@ -46,7 +61,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -62,7 +89,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -71,7 +98,55 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 
@@ -88,7 +163,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/4.0/php8.0/apache/Dockerfile
+++ b/4.0/php8.0/apache/Dockerfile
@@ -76,8 +76,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.0.5
-ENV JOOMLA_SHA512 8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877
+ENV JOOMLA_VERSION 4.0.6
+ENV JOOMLA_SHA512 a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/4.0/php8.0/apache/docker-entrypoint.sh
+++ b/4.0/php8.0/apache/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/4.0/php8.0/fpm-alpine/Dockerfile
+++ b/4.0/php8.0/fpm-alpine/Dockerfile
@@ -73,8 +73,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.0.5
-ENV JOOMLA_SHA512 8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877
+ENV JOOMLA_VERSION 4.0.6
+ENV JOOMLA_SHA512 a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/4.0/php8.0/fpm-alpine/Dockerfile
+++ b/4.0/php8.0/fpm-alpine/Dockerfile
@@ -10,10 +10,17 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# entrypoint.sh dependencies
-RUN apk add --no-cache \
-	bash
-# Install the PHP extensions
+RUN set -eux; \
+	apk add --no-cache \
+# in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
+		bash \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files
+		imagemagick \
+	;
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
@@ -22,20 +29,30 @@ RUN set -ex; \
 		bzip2-dev \
 		gmp-dev \
 		icu-dev \
+		freetype-dev \
+		imagemagick-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
-	docker-php-ext-configure ldap; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		intl \
@@ -46,6 +63,20 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
+	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
@@ -62,13 +93,43 @@ RUN set -ex; \
 	rm -r /tmp/pear; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		)"; \
-	apk add --virtual .joomla-phpext-rundeps $runDeps; \
-	apk del .build-deps
+		scanelf --needed --nobanner --format '%n#p' --recursive "$extDir" \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .joomla-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -85,7 +146,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/4.0/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/4.0/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/4.0/php8.0/fpm/Dockerfile
+++ b/4.0/php8.0/fpm/Dockerfile
@@ -74,8 +74,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.0.5
-ENV JOOMLA_SHA512 8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877
+ENV JOOMLA_VERSION 4.0.6
+ENV JOOMLA_SHA512 a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/4.0/php8.0/fpm/Dockerfile
+++ b/4.0/php8.0/fpm/Dockerfile
@@ -10,7 +10,15 @@ LABEL maintainer="Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joo
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-# Install the PHP extensions
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need.
 RUN set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -20,20 +28,29 @@ RUN set -ex; \
 		libbz2-dev \
 		libgmp-dev \
 		libicu-dev \
+		libfreetype6-dev \
 		libjpeg-dev \
 		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
-		libpng-dev \
+		libmagickwand-dev \
 		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg; \
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+	; \
 	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 		intl \
@@ -44,7 +61,19 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
 	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-5.1.21; \
 	pecl install memcached-3.1.5; \
@@ -60,7 +89,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -69,7 +98,37 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
 
 VOLUME /var/www/html
 
@@ -86,7 +145,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/4.0/php8.0/fpm/docker-entrypoint.sh
+++ b/4.0/php8.0/fpm/docker-entrypoint.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
-
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+                case "$1" in
+                apache2*)
+                        user="${APACHE_RUN_USER:-www-data}"
+                        group="${APACHE_RUN_GROUP:-www-data}"
+
+                        # strip off any '#' symbol ('#1000' is valid syntax for Apache)
+                        pound='#'
+                        user="${user#$pound}"
+                        group="${group#$pound}"
+                        ;;
+                *) # php-fpm
+                        user='www-data'
+                        group='www-data'
+                        ;;
+                esac
+        else
+                user="$uid"
+                group="$gid"
+        fi
+        # set user if not exist
+        if ! id "$user" &>/dev/null; then
+                # get the user name
+                : "${USER_NAME:=www-data}"
+                # change the user name
+                [[ "$USER_NAME" != "www-data" ]] &&
+                        usermod -l "$USER_NAME" www-data &&
+                        groupmod -n "$USER_NAME" www-data
+                # update the user ID
+                groupmod -o -g "$user" "$USER_NAME"
+                # update the user-group ID
+                usermod -o -u "$group" "$USER_NAME"
+        fi
+
         if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 if [ -z "$JOOMLA_DB_HOST" ]; then
                         JOOMLA_DB_HOST='mysql'
@@ -25,11 +60,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
         fi
 
         # If the DB user is 'root' then use the MySQL root password env var
-        : ${JOOMLA_DB_USER:=root}
+        : "${JOOMLA_DB_USER:=root}"
         if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
-        : ${JOOMLA_DB_NAME:=joomla}
+        : "${JOOMLA_DB_NAME:=joomla}"
 
         if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
@@ -39,23 +74,48 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
-                echo >&2 "Joomla not found in $(pwd) - copying now..."
-
-                if [ "$(ls -A)" ]; then
-                        echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
-                        ( set -x; ls -A; sleep 10 )
+        if [ ! -e index.php ] && [ ! -e libraries/src/Version.php ]; then
+                # if the directory exists and Joomla doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+                if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+                        chown "$user:$group" .
                 fi
 
-                tar cf - --one-file-system -C /usr/src/joomla . | tar xf -
+                echo >&2 "Joomla not found in $PWD - copying now..."
+                if [ "$(ls -A)" ]; then
+                        echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+                        (
+                                set -x
+                                ls -A
+                                sleep 10
+                        )
+                fi
+                # use full commands
+                # for clearer intent
+                sourceTarArgs=(
+                        --create
+                        --file -
+                        --directory /usr/src/joomla
+                        --one-file-system
+                        --owner "$user" --group "$group"
+                )
+                targetTarArgs=(
+                        --extract
+                        --file -
+                )
+                if [ "$uid" != '0' ]; then
+                        # avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+                        targetTarArgs+=(--no-overwrite-dir)
+                fi
+
+                tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
 
                 if [ ! -e .htaccess ]; then
                         # NOTE: The "Indexes" option is disabled in the php:apache base image so remove it as we enable .htaccess
-                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt > .htaccess
-                        chown www-data:www-data .htaccess
+                        sed -r 's/^(Options -Indexes.*)$/#\1/' htaccess.txt >.htaccess
+                        chown "$user":"$group" .htaccess
                 fi
 
-                echo >&2 "Complete! Joomla has been successfully copied to $(pwd)"
+                echo >&2 "Complete! Joomla has been successfully copied to $PWD"
         fi
 
         # Ensure the MySQL Database is created

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,18 +9,29 @@ LABEL maintainer="{{ env.joomlaMaintainers }}"
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 {{ if is_alpine then ( -}}
-# entrypoint.sh dependencies
-RUN apk add --no-cache \
-	bash
-{{ ) else "" end -}}
-{{ if env.variant == "apache" then ( -}}
-# Enable Apache Rewrite Module
-RUN a2enmod rewrite
-{{ ) else "" end -}}
-# Install the PHP extensions
+RUN set -eux; \
+	apk add --no-cache \
+# in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
+		bash \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files
+		imagemagick \
+	;
+{{ ) else ( -}}
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+{{ ) end -}}
+
+# install the PHP extensions we need.
 RUN set -ex; \
-{{ if is_alpine then ( -}}
 	\
+{{ if is_alpine then ( -}}
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		autoconf \
@@ -29,24 +40,59 @@ RUN set -ex; \
 {{ if env.version == "4.0" then ( -}}
 		icu-dev \
 {{ ) else "" end -}}
+		freetype-dev \
+		imagemagick-dev \
 		libjpeg-turbo-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 		openldap-dev \
 		pcre-dev \
 		postgresql-dev \
 	; \
-	\
-{{ if env.phpVersion == "7.3" then ( -}}
-	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
 {{ ) else ( -}}
-	docker-php-ext-configure gd --with-jpeg; \
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libbz2-dev \
+		libgmp-dev \
+{{ if env.version == "4.0" then ( -}}
+		libicu-dev \
+{{ ) else "" end -}}
+		libfreetype6-dev \
+		libjpeg-dev \
+		libldap2-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libmagickwand-dev \
+		libpq-dev \
+		libpng-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
 {{ ) end -}}
-	docker-php-ext-configure ldap; \
+	\
+	docker-php-ext-configure gd \
+{{ if env.phpVersion == "7.3" then ( -}}
+		--with-freetype-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-png-dir=/usr \
+		--with-webp-dir=/usr \
+{{ ) else ( -}}
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+{{ ) end -}}
+	; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install -j "$(nproc)" \
 		bz2 \
+		bcmath \
+		exif \
 		gd \
 		gmp \
 {{ if env.version == "4.0" then ( -}}
@@ -59,6 +105,23 @@ RUN set -ex; \
 		pgsql \
 		zip \
 	; \
+{{ if is_alpine then ( -}}
+# WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
+{{ ) else "" end -}}
+# https://pecl.php.net/package/imagick
+	pecl install imagick-3.6.0; \
+	docker-php-ext-enable imagick; \
+	rm -r /tmp/pear; \
+	\
+# some misbehaving extensions end up outputting to stdout
+	out="$(php -r 'exit(0);')"; \
+	[ -z "$out" ]; \
+	err="$(php -r 'exit(0);' 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]; \
+	\
+	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
+	[ -d "$extDir" ]; \
+{{ if is_alpine then ( -}}
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-{{ env.pecl_APCu }}; \
@@ -75,55 +138,14 @@ RUN set -ex; \
 	rm -r /tmp/pear; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		)"; \
-	apk add --virtual .joomla-phpext-rundeps $runDeps; \
-	apk del .build-deps
+		scanelf --needed --nobanner --format '%n#p' --recursive "$extDir" \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .joomla-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps; \
 {{ ) else ( -}}
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libbz2-dev \
-		libgmp-dev \
-{{ if env.version == "4.0" then ( -}}
-		libicu-dev \
-{{ ) else "" end -}}
-		libjpeg-dev \
-		libldap2-dev \
-		libmcrypt-dev \
-		libmemcached-dev \
-		libpng-dev \
-		libpq-dev \
-		libzip-dev \
-	; \
-	\
-{{ if env.phpVersion == "7.3" then ( -}}
-	docker-php-ext-configure gd --with-jpeg-dir=/usr --with-png-dir=/usr; \
-{{ ) else ( -}}
-	docker-php-ext-configure gd --with-jpeg; \
-{{ ) end -}}
-	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
-	docker-php-ext-install -j "$(nproc)" \
-		bz2 \
-		gd \
-		gmp \
-{{ if env.version == "4.0" then ( -}}
-		intl \
-{{ ) else "" end -}}
-		ldap \
-		mysqli \
-		pdo_mysql \
-		pdo_pgsql \
-		pgsql \
-		zip \
-	; \
-	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
 	pecl install APCu-{{ env.pecl_APCu }}; \
 	pecl install memcached-{{ env.pecl_memcached }}; \
@@ -139,7 +161,7 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+	ldd "$extDir"/*.so \
 		| awk '/=>/ { print $3 }' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
@@ -148,8 +170,58 @@ RUN set -ex; \
 		| xargs -rt apt-mark manual; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
+	\
+	! { ldd "$extDir"/*.so | grep 'not found'; }; \
+# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
+	err="$(php --version 3>&1 1>&2 2>&3)"; \
+	[ -z "$err" ]
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN set -eux; \
+	docker-php-ext-enable opcache; \
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set recommended error logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+{{ if env.variant == "apache" then ( -}}
+
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
+{{ ) else "" end -}}
 
 VOLUME /var/www/html
 
@@ -166,7 +238,7 @@ RUN set -ex; \
 	rm joomla.tar.bz2; \
 	chown -R www-data:www-data /usr/src/joomla
 
-# Copy init scripts and custom .htaccess
+# Copy init scripts
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -f "$JOOMLA_DB_PASSWORD_FILE" ]]; then
+if [ -n "$JOOMLA_DB_PASSWORD_FILE" ] && [ -f "$JOOMLA_DB_PASSWORD_FILE" ]; then
         JOOMLA_DB_PASSWORD=$(cat "$JOOMLA_DB_PASSWORD_FILE")
 fi
 

--- a/versions-helper.json
+++ b/versions-helper.json
@@ -1,6 +1,6 @@
 {
   "4.0": {
-    "version": "4.0.5",
+    "version": "4.0.6",
     "php": "8.0",
     "aliases": [4, "latest"],
     "phpVersions": {

--- a/versions-helper.json
+++ b/versions-helper.json
@@ -29,7 +29,7 @@
     ]
   },
   "3.10": {
-    "version": "3.10.4",
+    "version": "3.10.5",
     "php": "7.4",
     "aliases": [3],
     "phpVersions": {

--- a/versions.json
+++ b/versions.json
@@ -8,14 +8,14 @@
       "7.3",
       "7.4"
     ],
-    "sha512": "c5c67067b2f8b7732b518f620a4a07e3471a9a682724e72ca64db27a7c85f8bddc66bc6abc73b4b10062db3228ebb65573a89ad9c026ff27d4cbe51f82f3d510",
+    "sha512": "c635370d2dc9f1b8aab98751b15e7a3085b41deb47d578172c702f7d63967b9968fb35929a7131aa0ecf63529a7b166bc9976a3ced01fac5ee4941337c65eb37",
     "variant": "apache",
     "variants": [
       "apache",
       "fpm-alpine",
       "fpm"
     ],
-    "version": "3.10.4"
+    "version": "3.10.5"
   },
   "4.0": {
     "aliases": [

--- a/versions.json
+++ b/versions.json
@@ -27,13 +27,13 @@
       "7.4",
       "8.0"
     ],
-    "sha512": "8c85c444e9183bbe11660202c860b7c8bd5d50ddde6aa5212d183fecb58f04d42a0203f05a996dfc1fd8b037d9130dad89f38f5f4f7889561879df9809253877",
+    "sha512": "a35f3181c594ef0c30e4f8ec122f32e2ebe1795ccd31f55656be0f214b1f6eed54ef7961aed0be772b2c4a6cc5d0e6454b9213f1ba8833dd52317c6d216d9fd8",
     "variant": "apache",
     "variants": [
       "apache",
       "fpm-alpine",
       "fpm"
     ],
-    "version": "4.0.5"
+    "version": "4.0.6"
   }
 }


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@ac73b16: Update images of Joomla! with template improvements made.
- joomla-docker/docker-joomla@46f887f: Adds ghostscript, imagemagick, freetype-dev, imagemagick-dev, libwebp-dev to ALPINE
- joomla-docker/docker-joomla@46f887f: Adds ghostscript, libfreetype6-dev, libmagickwand-dev, libpng-dev, libwebp-dev to DEBIAN
- joomla-docker/docker-joomla@46f887f: Adds bcmath, exif to BOTH
- joomla-docker/docker-joomla@46f887f: Adds set recommended PHP.ini settings
- joomla-docker/docker-joomla@46f887f: Adds Default error logging as recommended by PHP
- joomla-docker/docker-joomla@46f887f: Adds RemoteIP config for better Docker integration
-  joomla-docker/docker-joomla@46f887f: Improves docker-php-ext-configure gd
- joomla-docker/docker-joomla@46f887f: Improves Pecl area format
- joomla-docker/docker-joomla@e49b190a: Adds option to set the user_ID and user_group_ID for apache images.
- joomla-docker/docker-joomla@58b776e: Adds check to make sure the JOOMLA_DB_PASSWORD_FILE is set before trying to check if the path exist.
- joomla-docker/docker-joomla@05d90f4: Update images of Joomla! 4.0.5 to 4.0.6
- joomla-docker/docker-joomla@f629593: Update version of Joomla! 4.0.5 to 4.0.6
- joomla-docker/docker-joomla@3510137: Update images of Joomla! 3.10.4 to 3.10.5
- joomla-docker/docker-joomla@785ffd3: Update version of Joomla! 3.10.4 to 3.10.5

These changes has been tested in [my test images](https://github.com/octoleo/docker-joomla) for the last month.