### PR TITLE
Use `mysqli_report(MYSQLI_REPORT_OFF)` in `makedb.php`

### DIFF
--- a/3.10/php7.4/apache/makedb.php
+++ b/3.10/php7.4/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/3.10/php7.4/fpm-alpine/makedb.php
+++ b/3.10/php7.4/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/3.10/php7.4/fpm/makedb.php
+++ b/3.10/php7.4/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php7.4/apache/makedb.php
+++ b/4.2/php7.4/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php7.4/fpm-alpine/makedb.php
+++ b/4.2/php7.4/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php7.4/fpm/makedb.php
+++ b/4.2/php7.4/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.0/apache/makedb.php
+++ b/4.2/php8.0/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.0/fpm-alpine/makedb.php
+++ b/4.2/php8.0/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.0/fpm/makedb.php
+++ b/4.2/php8.0/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.1/apache/makedb.php
+++ b/4.2/php8.1/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.1/fpm-alpine/makedb.php
+++ b/4.2/php8.1/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.1/fpm/makedb.php
+++ b/4.2/php8.1/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/makedb.php
+++ b/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);


### PR DESCRIPTION
Using PHP 8.1, the `makedb.php` script fails if the connection cannot be established at the first try.  This is because according to https://www.php.net/manual/en/mysqli-driver.report-mode.php, the default mysqli reporting mode is now `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` while it was `MYSQLI_REPORT_OFF` before.  The change makes `mysqli::__construct()` throw an exception, which is not caught.  This commit restores the old behavior.

Note that I tested only the `php8.1-fpm-alpine` variant (which works).