### PR TITLE
Update Joomla to 4.2.3

### DIFF
--- a/3.10/php7.4/apache/makedb.php
+++ b/3.10/php7.4/apache/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/3.10/php7.4/apache/makedb.php
+++ b/3.10/php7.4/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/3.10/php7.4/fpm-alpine/makedb.php
+++ b/3.10/php7.4/fpm-alpine/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/3.10/php7.4/fpm-alpine/makedb.php
+++ b/3.10/php7.4/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/3.10/php7.4/fpm/makedb.php
+++ b/3.10/php7.4/fpm/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/3.10/php7.4/fpm/makedb.php
+++ b/3.10/php7.4/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php7.4/apache/Dockerfile
+++ b/4.2/php7.4/apache/Dockerfile
@@ -150,12 +150,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php7.4/apache/makedb.php
+++ b/4.2/php7.4/apache/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php7.4/apache/makedb.php
+++ b/4.2/php7.4/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php7.4/fpm-alpine/Dockerfile
+++ b/4.2/php7.4/fpm-alpine/Dockerfile
@@ -130,12 +130,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php7.4/fpm-alpine/makedb.php
+++ b/4.2/php7.4/fpm-alpine/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php7.4/fpm-alpine/makedb.php
+++ b/4.2/php7.4/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php7.4/fpm/Dockerfile
+++ b/4.2/php7.4/fpm/Dockerfile
@@ -132,12 +132,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php7.4/fpm/makedb.php
+++ b/4.2/php7.4/fpm/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php7.4/fpm/makedb.php
+++ b/4.2/php7.4/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.0/apache/Dockerfile
+++ b/4.2/php8.0/apache/Dockerfile
@@ -150,12 +150,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php8.0/apache/makedb.php
+++ b/4.2/php8.0/apache/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php8.0/apache/makedb.php
+++ b/4.2/php8.0/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.0/fpm-alpine/Dockerfile
+++ b/4.2/php8.0/fpm-alpine/Dockerfile
@@ -130,12 +130,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php8.0/fpm-alpine/makedb.php
+++ b/4.2/php8.0/fpm-alpine/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php8.0/fpm-alpine/makedb.php
+++ b/4.2/php8.0/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.0/fpm/Dockerfile
+++ b/4.2/php8.0/fpm/Dockerfile
@@ -132,12 +132,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php8.0/fpm/makedb.php
+++ b/4.2/php8.0/fpm/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php8.0/fpm/makedb.php
+++ b/4.2/php8.0/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.1/apache/Dockerfile
+++ b/4.2/php8.1/apache/Dockerfile
@@ -150,12 +150,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php8.1/apache/makedb.php
+++ b/4.2/php8.1/apache/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php8.1/apache/makedb.php
+++ b/4.2/php8.1/apache/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.1/fpm-alpine/Dockerfile
+++ b/4.2/php8.1/fpm-alpine/Dockerfile
@@ -130,12 +130,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php8.1/fpm-alpine/makedb.php
+++ b/4.2/php8.1/fpm-alpine/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php8.1/fpm-alpine/makedb.php
+++ b/4.2/php8.1/fpm-alpine/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/4.2/php8.1/fpm/Dockerfile
+++ b/4.2/php8.1/fpm/Dockerfile
@@ -132,12 +132,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 4.2.2
-ENV JOOMLA_SHA512 388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b
+ENV JOOMLA_VERSION 4.2.3
+ENV JOOMLA_SHA512 8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2; \
+	curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2; \
 	echo "$JOOMLA_SHA512 *joomla.tar.bz2" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar -xf joomla.tar.bz2 -C /usr/src/joomla; \

--- a/4.2/php8.1/fpm/makedb.php
+++ b/4.2/php8.1/fpm/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/4.2/php8.1/fpm/makedb.php
+++ b/4.2/php8.1/fpm/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -37,7 +37,7 @@ RUN set -ex; \
 		autoconf \
 		bzip2-dev \
 		gmp-dev \
-{{ if env.version == "4.2" then ( -}}
+{{ if env.version != "3.10" then ( -}}
 		icu-dev \
 {{ ) else "" end -}}
 		freetype-dev \
@@ -61,7 +61,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libgmp-dev \
-{{ if env.version == "4.2" then ( -}}
+{{ if env.version != "3.10" then ( -}}
 		libicu-dev \
 {{ ) else "" end -}}
 		libfreetype6-dev \
@@ -96,7 +96,7 @@ RUN set -ex; \
 		exif \
 		gd \
 		gmp \
-{{ if env.version == "4.2" then ( -}}
+{{ if env.version != "3.10" then ( -}}
 		intl \
 {{ ) else "" end -}}
 		ldap \

--- a/makedb.php
+++ b/makedb.php
@@ -15,6 +15,8 @@ else
 
 $maxTries = 10;
 
+// set original default behaviour for PHP 8.1 and higher
+// see https://www.php.net/manual/en/mysqli-driver.report-mode.php
 mysqli_report(MYSQLI_REPORT_OFF);
 do
 {

--- a/makedb.php
+++ b/makedb.php
@@ -15,6 +15,7 @@ else
 
 $maxTries = 10;
 
+mysqli_report(MYSQLI_REPORT_OFF);
 do
 {
 	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);

--- a/versions-helper.json
+++ b/versions-helper.json
@@ -1,6 +1,6 @@
 {
   "4.2": {
-    "version": "4.2.2",
+    "version": "4.2.3",
     "php": "8.0",
     "aliases": [4, "latest"],
     "phpVersions": {

--- a/versions.json
+++ b/versions.json
@@ -22,20 +22,20 @@
       4,
       "latest"
     ],
-    "package": "https://github.com/joomla/joomla-cms/releases/download/4.2.2/Joomla_4.2.2-Stable-Full_Package.tar.bz2",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/4.2.3/Joomla_4.2.3-Stable-Full_Package.tar.bz2",
     "php": "8.0",
     "phpVersions": [
       "7.4",
       "8.0",
       "8.1"
     ],
-    "sha512": "388e91bacee7ff1e07d7fc02df9fb8b5728f960fb4eb8f75679891b029d27ecb7f692b420259bae107e212ca88cecc4804ae0f61a1e771c7b6dd0208cdb04d7b",
+    "sha512": "8d24be3f0f1dd616d4ddc84ace89f7944b23bb32037a198b5c04c1f9e39c59a4496c760b5dd71bafe5b081799be630f2a905b11093760a9eb183e8f62db6d0bb",
     "variant": "apache",
     "variants": [
       "apache",
       "fpm-alpine",
       "fpm"
     ],
-    "version": "4.2.2"
+    "version": "4.2.3"
   }
 }


### PR DESCRIPTION
- joomla-docker/docker-joomla@445bd47c26514393d5f5beb5e3b1ab2e0d667f53: Update images of Joomla! 4.2.2 to 4.2.3
- joomla-docker/docker-joomla@7d88abf94a1ee64b90eeae53354ee809fe5ddce3: Update version of Joomla! 4.2.2 to 4.2.3
- joomla-docker/docker-joomla@5db422d45ababc59434db274f640a152063ee514: Adds notice to mysqli-driver fix. Improved the Dockerflie.template.
- joomla-docker/docker-joomla@ffbb7e38541a761939494d17ed5975939ceb0bf0: Use mysqli_report(MYSQLI_REPORT_OFF) in makedb.php