### PR TITLE
Update Joomla 5.3.0-beta1 to 5.3.0-beta2.

### DIFF
--- a/5.2/php8.3/apache/Dockerfile
+++ b/5.2/php8.3/apache/Dockerfile
@@ -87,9 +87,9 @@ RUN set -ex; \
 	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
 	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-	pecl install APCu-5.1.23; \
+	pecl install APCu-5.1.24; \
 	pecl install memcached-3.3.0; \
-	pecl install redis-6.0.2; \
+	pecl install redis-6.1.0; \
 	\
 	docker-php-ext-enable \
 		apcu \

--- a/5.2/php8.3/fpm-alpine/Dockerfile
+++ b/5.2/php8.3/fpm-alpine/Dockerfile
@@ -90,9 +90,9 @@ RUN set -ex; \
 	[ -d "$extDir" ]; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
-	pecl install APCu-5.1.23; \
+	pecl install APCu-5.1.24; \
 	pecl install memcached-3.3.0; \
-	pecl install redis-6.0.2; \
+	pecl install redis-6.1.0; \
 	\
 	docker-php-ext-enable \
 		apcu \

--- a/5.2/php8.3/fpm/Dockerfile
+++ b/5.2/php8.3/fpm/Dockerfile
@@ -87,9 +87,9 @@ RUN set -ex; \
 	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
 	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-	pecl install APCu-5.1.23; \
+	pecl install APCu-5.1.24; \
 	pecl install memcached-3.3.0; \
-	pecl install redis-6.0.2; \
+	pecl install redis-6.1.0; \
 	\
 	docker-php-ext-enable \
 		apcu \

--- a/5.3.beta/php8.1/apache/Dockerfile
+++ b/5.3.beta/php8.1/apache/Dockerfile
@@ -162,12 +162,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.1/fpm-alpine/Dockerfile
+++ b/5.3.beta/php8.1/fpm-alpine/Dockerfile
@@ -142,12 +142,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.1/fpm/Dockerfile
+++ b/5.3.beta/php8.1/fpm/Dockerfile
@@ -144,12 +144,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.2/apache/Dockerfile
+++ b/5.3.beta/php8.2/apache/Dockerfile
@@ -162,12 +162,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.2/fpm-alpine/Dockerfile
+++ b/5.3.beta/php8.2/fpm-alpine/Dockerfile
@@ -142,12 +142,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.2/fpm/Dockerfile
+++ b/5.3.beta/php8.2/fpm/Dockerfile
@@ -144,12 +144,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.3/apache/Dockerfile
+++ b/5.3.beta/php8.3/apache/Dockerfile
@@ -87,9 +87,9 @@ RUN set -ex; \
 	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
 	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-	pecl install APCu-5.1.23; \
+	pecl install APCu-5.1.24; \
 	pecl install memcached-3.3.0; \
-	pecl install redis-6.0.2; \
+	pecl install redis-6.1.0; \
 	\
 	docker-php-ext-enable \
 		apcu \
@@ -162,12 +162,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.3/fpm-alpine/Dockerfile
+++ b/5.3.beta/php8.3/fpm-alpine/Dockerfile
@@ -90,9 +90,9 @@ RUN set -ex; \
 	[ -d "$extDir" ]; \
 	\
 # pecl will claim success even if one install fails, so we need to perform each install separately
-	pecl install APCu-5.1.23; \
+	pecl install APCu-5.1.24; \
 	pecl install memcached-3.3.0; \
-	pecl install redis-6.0.2; \
+	pecl install redis-6.1.0; \
 	\
 	docker-php-ext-enable \
 		apcu \
@@ -142,12 +142,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.3.beta/php8.3/fpm/Dockerfile
+++ b/5.3.beta/php8.3/fpm/Dockerfile
@@ -87,9 +87,9 @@ RUN set -ex; \
 	extDir="$(php -r 'echo ini_get("extension_dir");')"; \
 	[ -d "$extDir" ]; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-	pecl install APCu-5.1.23; \
+	pecl install APCu-5.1.24; \
 	pecl install memcached-3.3.0; \
-	pecl install redis-6.0.2; \
+	pecl install redis-6.1.0; \
 	\
 	docker-php-ext-enable \
 		apcu \
@@ -144,12 +144,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.3.0-beta1
-ENV JOOMLA_SHA512 5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef
+ENV JOOMLA_VERSION 5.3.0-beta2
+ENV JOOMLA_SHA512 1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/versions-helper.json
+++ b/versions-helper.json
@@ -1,16 +1,16 @@
 {
   "5.3.beta": {
-    "version": "5.3.0-beta1",
-    "package": "https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst",
+    "version": "5.3.0-beta2",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst",
     "packageType": "tar.zst",
-    "php": "8.2",
+    "php": "8.3",
     "aliases": ["5.3.0-beta"],
     "phpVersions": {
       "8.3": {
         "pecl": {
-          "APCu": "5.1.23",
+          "APCu": "5.1.24",
           "memcached": "3.3.0",
-          "redis": "6.0.2"
+          "redis": "6.1.0"
         }
       },
       "8.2": {
@@ -38,14 +38,14 @@
   "5.2": {
     "version": "5.2.4",
     "packageType": "tar.zst",
-    "php": "8.2",
+    "php": "8.3",
     "aliases": [5, "latest"],
     "phpVersions": {
       "8.3": {
         "pecl": {
-          "APCu": "5.1.23",
+          "APCu": "5.1.24",
           "memcached": "3.3.0",
-          "redis": "6.0.2"
+          "redis": "6.1.0"
         }
       },
       "8.2": {
@@ -72,7 +72,7 @@
   },
   "4.4": {
     "version": "4.4.11",
-    "php": "8.1",
+    "php": "8.2",
     "aliases": [4],
     "phpVersions": {
       "8.2": {

--- a/versions.json
+++ b/versions.json
@@ -5,7 +5,7 @@
     ],
     "package": "https://github.com/joomla/joomla-cms/releases/download/4.4.11/Joomla_4.4.11-Stable-Full_Package.tar.bz2",
     "packageType": "tar.bz2",
-    "php": "8.1",
+    "php": "8.2",
     "phpVersions": [
       "8.1",
       "8.2"
@@ -26,7 +26,7 @@
     ],
     "package": "https://github.com/joomla/joomla-cms/releases/download/5.2.4/Joomla_5.2.4-Stable-Full_Package.tar.zst",
     "packageType": "tar.zst",
-    "php": "8.2",
+    "php": "8.3",
     "phpVersions": [
       "8.1",
       "8.2",
@@ -45,21 +45,21 @@
     "aliases": [
       "5.3.0-beta"
     ],
-    "package": "https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta1/Joomla_5.3.0-beta1-Beta-Full_Package.tar.zst",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/5.3.0-beta2/Joomla_5.3.0-beta2-Beta-Full_Package.tar.zst",
     "packageType": "tar.zst",
-    "php": "8.2",
+    "php": "8.3",
     "phpVersions": [
       "8.1",
       "8.2",
       "8.3"
     ],
-    "sha512": "5fb97e559704150e305b3d7a8e333040d1d7af41ad5e5453c001596a71526b3fe95d602f3ef825368a1f283b1130d2be3797e2b5144a221041e28406a48179ef",
+    "sha512": "1219caf8ac33f72a29641652cc31a92c07cde5f98b601664f66978e899a717338b64025dc53f846f5e76bb8b2fb77367e970929be6b0de66edbbce2356e2f03c",
     "variant": "apache",
     "variants": [
       "apache",
       "fpm-alpine",
       "fpm"
     ],
-    "version": "5.3.0-beta1"
+    "version": "5.3.0-beta2"
   }
 }


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@ad3bbae Update Joomla 5.3.0-beta1 to 5.3.0-beta2. Set new default correct PHP versions on each Joomla version.