### PR TITLE
Update Joomla! beta images

### DIFF
--- a/5.4.beta/php8.2/apache/Dockerfile
+++ b/5.4.beta/php8.2/apache/Dockerfile
@@ -151,12 +151,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.4.0-beta1
-ENV JOOMLA_SHA512 d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d
+ENV JOOMLA_VERSION 5.4.0-beta2
+ENV JOOMLA_SHA512 1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.4.beta/php8.2/fpm-alpine/Dockerfile
+++ b/5.4.beta/php8.2/fpm-alpine/Dockerfile
@@ -131,12 +131,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.4.0-beta1
-ENV JOOMLA_SHA512 d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d
+ENV JOOMLA_VERSION 5.4.0-beta2
+ENV JOOMLA_SHA512 1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.4.beta/php8.2/fpm/Dockerfile
+++ b/5.4.beta/php8.2/fpm/Dockerfile
@@ -133,12 +133,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.4.0-beta1
-ENV JOOMLA_SHA512 d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d
+ENV JOOMLA_VERSION 5.4.0-beta2
+ENV JOOMLA_SHA512 1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.4.beta/php8.3/apache/Dockerfile
+++ b/5.4.beta/php8.3/apache/Dockerfile
@@ -151,12 +151,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.4.0-beta1
-ENV JOOMLA_SHA512 d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d
+ENV JOOMLA_VERSION 5.4.0-beta2
+ENV JOOMLA_SHA512 1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.4.beta/php8.3/fpm-alpine/Dockerfile
+++ b/5.4.beta/php8.3/fpm-alpine/Dockerfile
@@ -131,12 +131,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.4.0-beta1
-ENV JOOMLA_SHA512 d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d
+ENV JOOMLA_VERSION 5.4.0-beta2
+ENV JOOMLA_SHA512 1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/5.4.beta/php8.3/fpm/Dockerfile
+++ b/5.4.beta/php8.3/fpm/Dockerfile
@@ -133,12 +133,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 5.4.0-beta1
-ENV JOOMLA_SHA512 d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d
+ENV JOOMLA_VERSION 5.4.0-beta2
+ENV JOOMLA_SHA512 1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/6.0.beta/php8.3/apache/Dockerfile
+++ b/6.0.beta/php8.3/apache/Dockerfile
@@ -151,12 +151,12 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 6.0.0-beta1
-ENV JOOMLA_SHA512 8b042d25a2f3074b0190403b42032457eee30fb3fb6b67b345f6dd355c1636b5eb862abefe281c7335ae2fd657a718df329586ea9ca11a07c57962786dccf1eb
+ENV JOOMLA_VERSION 6.0.0-beta2
+ENV JOOMLA_SHA512 41baabb3f820c36daccde6c5f8834e7893f0f19687b0c286970d00f52f71c2185c117e45344f395133041449ebb638ac4055ea1accde8d4ff47e36e3238beb38
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta1/Joomla_6.0.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta2/Joomla_6.0.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/6.0.beta/php8.3/fpm-alpine/Dockerfile
+++ b/6.0.beta/php8.3/fpm-alpine/Dockerfile
@@ -131,12 +131,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 6.0.0-beta1
-ENV JOOMLA_SHA512 8b042d25a2f3074b0190403b42032457eee30fb3fb6b67b345f6dd355c1636b5eb862abefe281c7335ae2fd657a718df329586ea9ca11a07c57962786dccf1eb
+ENV JOOMLA_VERSION 6.0.0-beta2
+ENV JOOMLA_SHA512 41baabb3f820c36daccde6c5f8834e7893f0f19687b0c286970d00f52f71c2185c117e45344f395133041449ebb638ac4055ea1accde8d4ff47e36e3238beb38
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta1/Joomla_6.0.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta2/Joomla_6.0.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/6.0.beta/php8.3/fpm/Dockerfile
+++ b/6.0.beta/php8.3/fpm/Dockerfile
@@ -133,12 +133,12 @@ RUN { \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA512 signature
-ENV JOOMLA_VERSION 6.0.0-beta1
-ENV JOOMLA_SHA512 8b042d25a2f3074b0190403b42032457eee30fb3fb6b67b345f6dd355c1636b5eb862abefe281c7335ae2fd657a718df329586ea9ca11a07c57962786dccf1eb
+ENV JOOMLA_VERSION 6.0.0-beta2
+ENV JOOMLA_SHA512 41baabb3f820c36daccde6c5f8834e7893f0f19687b0c286970d00f52f71c2185c117e45344f395133041449ebb638ac4055ea1accde8d4ff47e36e3238beb38
 
 # Download package and extract to web volume
 RUN set -ex; \
-	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta1/Joomla_6.0.0-beta1-Beta-Full_Package.tar.zst; \
+	curl -o joomla.tar.zst -SL https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta2/Joomla_6.0.0-beta2-Beta-Full_Package.tar.zst; \
 	echo "$JOOMLA_SHA512 *joomla.tar.zst" | sha512sum -c -; \
 	mkdir /usr/src/joomla; \
 	tar --zstd -xf joomla.tar.zst -C /usr/src/joomla; \

--- a/versions-helper.json
+++ b/versions-helper.json
@@ -1,7 +1,7 @@
 {
   "6.0.beta": {
-    "version": "6.0.0-beta1",
-    "package": "https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta1/Joomla_6.0.0-beta1-Beta-Full_Package.tar.zst",
+    "version": "6.0.0-beta2",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta2/Joomla_6.0.0-beta2-Beta-Full_Package.tar.zst",
     "packageType": "tar.zst",
     "php": "8.3",
     "aliases": ["6.0.0-beta"],
@@ -22,8 +22,8 @@
     ]
   },
   "5.4.beta": {
-    "version": "5.4.0-beta1",
-    "package": "https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst",
+    "version": "5.4.0-beta2",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst",
     "packageType": "tar.zst",
     "php": "8.3",
     "aliases": ["5.4.0-beta"],

--- a/versions.json
+++ b/versions.json
@@ -25,39 +25,39 @@
     "aliases": [
       "5.4.0-beta"
     ],
-    "package": "https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta1/Joomla_5.4.0-beta1-Beta-Full_Package.tar.zst",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/5.4.0-beta2/Joomla_5.4.0-beta2-Beta-Full_Package.tar.zst",
     "packageType": "tar.zst",
     "php": "8.3",
     "phpVersions": [
       "8.2",
       "8.3"
     ],
-    "sha512": "d381bfa727d319eb4d528d5a77774b93698e7acbd0b763fe5f65195825f2ac3f75a2e188aa3d9bc67fccb4e42d561207afa34d8b5aa73a19b3f69e674d745e0d",
+    "sha512": "1f9c624fc09ac7401d62c9cb9111130a9c1b7d0ea468e0115aa7be4a5ac03c1d577de5c6a47fe9f4e67c55472300ff68556a45ac7dcda9757af3b41cf99b974e",
     "variant": "apache",
     "variants": [
       "apache",
       "fpm-alpine",
       "fpm"
     ],
-    "version": "5.4.0-beta1"
+    "version": "5.4.0-beta2"
   },
   "6.0.beta": {
     "aliases": [
       "6.0.0-beta"
     ],
-    "package": "https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta1/Joomla_6.0.0-beta1-Beta-Full_Package.tar.zst",
+    "package": "https://github.com/joomla/joomla-cms/releases/download/6.0.0-beta2/Joomla_6.0.0-beta2-Beta-Full_Package.tar.zst",
     "packageType": "tar.zst",
     "php": "8.3",
     "phpVersions": [
       "8.3"
     ],
-    "sha512": "8b042d25a2f3074b0190403b42032457eee30fb3fb6b67b345f6dd355c1636b5eb862abefe281c7335ae2fd657a718df329586ea9ca11a07c57962786dccf1eb",
+    "sha512": "41baabb3f820c36daccde6c5f8834e7893f0f19687b0c286970d00f52f71c2185c117e45344f395133041449ebb638ac4055ea1accde8d4ff47e36e3238beb38",
     "variant": "apache",
     "variants": [
       "apache",
       "fpm-alpine",
       "fpm"
     ],
-    "version": "6.0.0-beta1"
+    "version": "6.0.0-beta2"
   }
 }


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@bcd2a5e: Update Joomla 5.4.0-beta1 to 5.4.0-beta2 and 6.0.0-beta1 to 6.0.0-beta2