### PR TITLE
feat(security): harden default PHP security directives in container image

### DIFF
--- a/5.4/php8.2/apache/Dockerfile
+++ b/5.4/php8.2/apache/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/5.4/php8.2/fpm-alpine/Dockerfile
+++ b/5.4/php8.2/fpm-alpine/Dockerfile
@@ -114,6 +114,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/5.4/php8.2/fpm/Dockerfile
+++ b/5.4/php8.2/fpm/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/5.4/php8.3/apache/Dockerfile
+++ b/5.4/php8.3/apache/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/5.4/php8.3/fpm-alpine/Dockerfile
+++ b/5.4/php8.3/fpm-alpine/Dockerfile
@@ -114,6 +114,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/5.4/php8.3/fpm/Dockerfile
+++ b/5.4/php8.3/fpm/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/6.1/php8.3/apache/Dockerfile
+++ b/6.1/php8.3/apache/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/6.1/php8.3/fpm-alpine/Dockerfile
+++ b/6.1/php8.3/fpm-alpine/Dockerfile
@@ -114,6 +114,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/6.1/php8.3/fpm/Dockerfile
+++ b/6.1/php8.3/fpm/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/6.1/php8.4/apache/Dockerfile
+++ b/6.1/php8.4/apache/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/6.1/php8.4/fpm-alpine/Dockerfile
+++ b/6.1/php8.4/fpm-alpine/Dockerfile
@@ -114,6 +114,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/6.1/php8.4/fpm/Dockerfile
+++ b/6.1/php8.4/fpm/Dockerfile
@@ -116,6 +116,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -191,6 +191,19 @@ RUN set -eux; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=2'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# set directives to improve security
+RUN { \
+		echo 'expose_php = Off'; \
+		echo 'session.cookie_httponly = On'; \
+		echo 'session.cookie_secure = On'; \
+		echo 'session.use_strict_mode = On'; \
+		echo 'session.use_cookies = On'; \
+		echo 'session.use_only_cookies = On'; \
+		echo 'session.cookie_samesite = Strict'; \
+		echo 'disable_functions = exec,passthru,shell_exec,system,proc_open,popen,parse_ini_file,show_source'; \
+		echo 'allow_url_fopen = Off'; \
+		echo 'allow_url_include = Off'; \
+	} > /usr/local/etc/php/conf.d/security.ini
 # set recommended error logging
 RUN { \
 # https://www.php.net/manual/en/errorfunc.constants.php


### PR DESCRIPTION
Disable PHP exposure with expose_php=Off;
Enforce stricter session cookie settings (httponly, secure, samesite, strict mode); 
Disable risky functions and URL include/fopen directives by default; 
Improve secure baseline for Joomla runtime containers